### PR TITLE
Enabled cross-building between Scala 2.11 and 2.12

### DIFF
--- a/core/kompics-scala.sbt
+++ b/core/kompics-scala.sbt
@@ -4,7 +4,9 @@ organization := "se.sics.kompics"
 
 version := "0.9.2-SNAPSHOT"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.2"
+
+crossScalaVersions := Seq("2.11.11", "2.12.2")
 
 scalacOptions ++= Seq("-deprecation","-feature")
 
@@ -15,8 +17,8 @@ resolvers += "Kompics Snapshots" at "http://kompics.sics.se/maven/snapshotreposi
 
 libraryDependencies += "se.sics.kompics" % "kompics-core" % "0.9.2-SNAPSHOT"
 libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
-libraryDependencies += "org.scalactic" %% "scalactic" % "2.2.6"
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.3"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % "test"
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "0.9.28" % "test"
 
 parallelExecution in Test := false
@@ -24,8 +26,8 @@ parallelExecution in Test := false
 publishMavenStyle := true
 //credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 publishTo <<= version { (v: String) =>
-	val kompics = "kompics.i.sics.se";
-	val keyFile = Path.userHome / ".ssh" / "id_rsa";
+	val kompics = "kompics.i.sics.se"
+	val keyFile = Path.userHome / ".ssh" / "id_rsa"
 	if (v.trim.endsWith("SNAPSHOT"))
 		Some(Resolver.sftp("SICS Snapshot Repository", kompics, "/home/maven/snapshotrepository") as("root", keyFile))
 	else

--- a/core/project/build.properties
+++ b/core/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/simulator/kompics-scala-simulator.sbt
+++ b/simulator/kompics-scala-simulator.sbt
@@ -4,7 +4,9 @@ organization := "se.sics.kompics"
 
 version := "0.9.2-SNAPSHOT"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.2"
+
+crossScalaVersions := Seq("2.11.11", "2.12.2")
 
 scalacOptions ++= Seq("-deprecation","-feature")
 
@@ -16,9 +18,9 @@ resolvers += "Kompics Snapshots" at "http://kompics.sics.se/maven/snapshotreposi
 libraryDependencies += "se.sics.kompics" %% "kompics-scala" % "0.9.2-SNAPSHOT"
 libraryDependencies += "se.sics.kompics.simulator" % "core" % "0.9.2-SNAPSHOT"
 libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
-libraryDependencies += "org.scalactic" %% "scalactic" % "2.2.6"
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
-libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
+libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.3"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % "test"
+libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.7.1"
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "0.9.28" % "test"
 
 parallelExecution in Test := false
@@ -26,8 +28,8 @@ parallelExecution in Test := false
 publishMavenStyle := true
 //credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 publishTo <<= version { (v: String) =>
-	val kompics = "kompics.i.sics.se";
-	val keyFile = Path.userHome / ".ssh" / "id_rsa";
+	val kompics = "kompics.i.sics.se"
+	val keyFile = Path.userHome / ".ssh" / "id_rsa"
 	if (v.trim.endsWith("SNAPSHOT"))
 		Some(Resolver.sftp("SICS Snapshot Repository", kompics, "/home/maven/snapshotrepository") as("root", keyFile))
 	else

--- a/simulator/project/build.properties
+++ b/simulator/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/simulator/src/test/scala/se/sics/kompics/sl/simulator/BasicTestSuite.scala
+++ b/simulator/src/test/scala/se/sics/kompics/sl/simulator/BasicTestSuite.scala
@@ -61,7 +61,7 @@ class BasicTestSuite extends FunSuite with Matchers {
 
 }
 
-object SimpleSimulation {
+case object SimpleSimulation {
     
     import Distributions._
     // needed for the distributions, but needs to be initialised after setting the seed


### PR DESCRIPTION
I noticed there wasn't yet a 2.12 version of kompics-scala, but figured you might want to keep 2.11 support for now. This change enables cross-builds using `+ publish`.